### PR TITLE
Unown the room when owner leaves room empty

### DIFF
--- a/src/server/rooms.service.js
+++ b/src/server/rooms.service.js
@@ -120,6 +120,9 @@ module.exports = class Rooms {
                     if (oldRoom.users.length > 0) {
                         oldRoom.ownerID = oldRoom.users[0];
                         console.log(`User ${oldRoom.owner} is now the owner`);
+                    } else if (oldRoom.users.length == 0) {
+                        oldRoom.ownerID = undefined;
+                        console.log(`Room ${oldRoom.id} is unowned`);
                     }
                 }
 


### PR DESCRIPTION
When the owner leave the room and it becomes empty, lets unown it.
So that the next one join it can be the owner.

A not owned room is already assigned to users in:
https://github.com/yuumasato/have_you_heard_back/blob/8ecd8880d04e74474c0b936034e9c9328b9efb04/src/server/rooms.service.js#L148