### PR TITLE
answer: Fix time spent to answer calculation

### DIFF
--- a/src/events/answer.js
+++ b/src/events/answer.js
@@ -13,10 +13,6 @@ module.exports = function(socket) {
 
         // Generate the answer to be registered immediately
         let now = Date.now();
-        let answer_timestamp = {
-            time: now,
-            answer: answer
-        }
 
         let userID = `user_${socket.id}`;
         debug(`Player ${userID} answered: ${answer}`);
@@ -51,8 +47,14 @@ module.exports = function(socket) {
                 return;
             }
 
+            // Calculate the time spent to answer
+            let answer_time = {
+                time: now - game.roundStart,
+                answer: answer
+            }
+
             // Provide the callback to call when successful
-            await Games.answer(redisIO, userID, game.id, answer_timestamp, (retGame) => {
+            await Games.answer(redisIO, userID, game.id, answer_time, (retGame) => {
 
                 let allAnswered = true;
                 let answers = {};

--- a/src/server/games.service.js
+++ b/src/server/games.service.js
@@ -370,7 +370,7 @@ module.exports = class Games {
     /**
      * Register the vote for an answer
      * */
-    static async answer(redisIO, userID, gameID, answer_timestamp, cb, errCB) {
+    static async answer(redisIO, userID, gameID, answer_time, cb, errCB) {
 
         async function op() {
             let toWatch = [userID, gameID];
@@ -390,10 +390,7 @@ module.exports = class Games {
             let updated = false;
             game.players.find((p) => {
                 if (p.id === user.id) {
-                    p.answer = answer_timestamp;
-
-                    // Calculate the interval
-                    p.answer['time'] = p.answer['time'] - game.roundStart;
+                    p.answer = answer_time;
                     updated = true;
                 }
             });


### PR DESCRIPTION
Calculate the time spent to answer once per event instead of
recalculating in each retry which lead to negative times.

Fixes #24

Signed-off-by: Anderson Toshiyuki Sasaki <anderson.sasaki@gmail.com>