### PR TITLE
Fix some auto player issues

### DIFF
--- a/test/auto_player/game_coordinator.py
+++ b/test/auto_player/game_coordinator.py
@@ -61,6 +61,7 @@ class GameCoordinator():
         time.sleep(0.4)
 
     def start_game(self):
+        [ p.event.clear() for p in self.players ]
         self.players[0].emit_start()
         [ p.event.wait() for p in self.players ]
         [ p.event.clear() for p in self.players ]

--- a/test/auto_player/player.py
+++ b/test/auto_player/player.py
@@ -81,6 +81,7 @@ class Player():
         @self.sio.event
         def persona(data):
             self.print_log('Received persona - ' + data)
+            self.event.set()
 
         @self.sio.on('round answers')
         def round_answers(data):


### PR DESCRIPTION
d5be922ebefcbc058dec46be0f706e5160e28ddf fixes the problem where a game would get stuck. More specifically the `game2` of the test set would not finish.

8b06e9218ca126ecf52cf646ce3a2b843ed93e28 fixes the problem where sometimes a game would get `not_set` as the winner of a game.
```
Checking results: game2                                                                                                                                        
  Game winner: Expected player 2, got not_set
```